### PR TITLE
Create settings account page view and controller

### DIFF
--- a/lib/controllers/settings_account_controller.dart
+++ b/lib/controllers/settings_account_controller.dart
@@ -1,0 +1,76 @@
+import 'dart:io';
+import 'package:flutter/foundation.dart' show Uint8List, kIsWeb;
+import 'package:get_it/get_it.dart';
+import 'package:image_picker/image_picker.dart';
+import 'package:openwardrobe/brick/models/user_profile.model.dart';
+import 'package:openwardrobe/repositories/app_repository.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+class SettingsAccountController {
+  final AppRepository _appRepository = GetIt.instance<AppRepository>();
+
+  Future<UserProfile> fetchUserProfile() async {
+    try {
+      final profiles = await _appRepository.get<UserProfile>();
+      return profiles.first;
+    } catch (e) {
+      throw Exception('Failed to fetch user profile: $e');
+    }
+  }
+
+  Future<void> upsertUserProfile(UserProfile profile) async {
+    try {
+      await _appRepository.upsert<UserProfile>(profile);
+    } catch (e) {
+      throw Exception('Failed to upsert user profile: $e');
+    }
+  }
+
+  Future<String> uploadAvatar(File imageFile) async {
+    try {
+      final response = await Supabase.instance.client.storage
+          .from('avatars')
+          .upload(imageFile.path, imageFile);
+      return response.data['path'];
+    } catch (e) {
+      throw Exception('Failed to upload avatar: $e');
+    }
+  }
+
+  Future<String> uploadWebAvatar(Uint8List imageBytes, String fileName) async {
+    try {
+      final response = await Supabase.instance.client.storage
+          .from('avatars')
+          .uploadBinary(fileName, imageBytes);
+      return response.data['path'];
+    } catch (e) {
+      throw Exception('Failed to upload web avatar: $e');
+    }
+  }
+
+  Future<File?> pickImage({bool fromGallery = false}) async {
+    final picker = ImagePicker();
+    final pickedFile = await picker.pickImage(
+      source: fromGallery ? ImageSource.gallery : ImageSource.camera,
+    );
+
+    if (pickedFile != null) {
+      return File(pickedFile.path);
+    } else {
+      return null;
+    }
+  }
+
+  Future<Uint8List?> pickWebImage() async {
+    final picker = ImagePicker();
+    final pickedFile = await picker.pickImage(
+      source: ImageSource.gallery,
+    );
+
+    if (pickedFile != null) {
+      return await pickedFile.readAsBytes();
+    } else {
+      return null;
+    }
+  }
+}

--- a/lib/di/service_locator.dart
+++ b/lib/di/service_locator.dart
@@ -5,8 +5,7 @@ import '../controllers/camera_controller.dart';
 import '../controllers/home_controller.dart';
 import '../controllers/wardrobe_controller.dart';
 import '../controllers/lookbook_controller.dart';
-
-
+import '../controllers/settings_account_controller.dart'; // Import the new controller
 
 final getIt = GetIt.instance;
 
@@ -19,5 +18,5 @@ void setupLocator() {
   getIt.registerLazySingleton<HomeController>(() => HomeController());
   getIt.registerLazySingleton<WardrobeController>(() => WardrobeController());
   getIt.registerLazySingleton<LookbookController>(() => LookbookController());
-
+  getIt.registerLazySingleton<SettingsAccountController>(() => SettingsAccountController()); // Register the new controller
 }

--- a/lib/router/app_router.dart
+++ b/lib/router/app_router.dart
@@ -11,6 +11,7 @@ import '../ui/screens/home/page.dart';
 import '../ui/screens/wardrobe/page.dart';
 import '../ui/screens/wardrobe/add/page.dart';
 import '../ui/widgets/scaffold_with_navbar.dart';
+import '../ui/screens/wardrobe/settings/account_page.dart'; // Import the new settings account page
 
 class AppRouter {
   static final GlobalKey<NavigatorState> _rootNavigatorKey =
@@ -42,6 +43,11 @@ class AppRouter {
         path: '/camera',
         name: 'Add Item',
         builder: (context, state) => const CameraScreen(),
+      ),
+      GoRoute(
+        path: '/settings/account',
+        name: 'SettingsAccount',
+        builder: (context, state) => const SettingsAccountPage(),
       ),
       StatefulShellRoute.indexedStack(
         builder: (context, state, navigationShell) {

--- a/lib/ui/screens/wardrobe/settings/account_page.dart
+++ b/lib/ui/screens/wardrobe/settings/account_page.dart
@@ -1,0 +1,116 @@
+import 'package:flutter/material.dart';
+import 'package:get_it/get_it.dart';
+import 'package:openwardrobe/controllers/settings_account_controller.dart';
+import 'package:openwardrobe/brick/models/user_profile.model.dart';
+
+class SettingsAccountPage extends StatefulWidget {
+  const SettingsAccountPage({Key? key}) : super(key: key);
+
+  @override
+  _SettingsAccountPageState createState() => _SettingsAccountPageState();
+}
+
+class _SettingsAccountPageState extends State<SettingsAccountPage> {
+  final SettingsAccountController _controller = GetIt.instance<SettingsAccountController>();
+  late Future<UserProfile> _userProfileFuture;
+  final TextEditingController _usernameController = TextEditingController();
+  final TextEditingController _displayNameController = TextEditingController();
+  final TextEditingController _bioController = TextEditingController();
+  String? _avatarUrl;
+
+  @override
+  void initState() {
+    super.initState();
+    _userProfileFuture = _controller.fetchUserProfile();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Account Settings'),
+      ),
+      body: FutureBuilder<UserProfile>(
+        future: _userProfileFuture,
+        builder: (context, snapshot) {
+          if (snapshot.connectionState == ConnectionState.waiting) {
+            return const Center(child: CircularProgressIndicator());
+          } else if (snapshot.hasError) {
+            return Center(child: Text('Error: ${snapshot.error}'));
+          } else if (!snapshot.hasData) {
+            return const Center(child: Text('No profile found'));
+          }
+
+          final userProfile = snapshot.data!;
+          _usernameController.text = userProfile.username;
+          _displayNameController.text = userProfile.displayName ?? '';
+          _bioController.text = userProfile.bio ?? '';
+          _avatarUrl = userProfile.avatarUrl;
+
+          return Padding(
+            padding: const EdgeInsets.all(16.0),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Center(
+                  child: GestureDetector(
+                    onTap: () async {
+                      final imageFile = await _controller.pickImage(fromGallery: true);
+                      if (imageFile != null) {
+                        final avatarUrl = await _controller.uploadAvatar(imageFile);
+                        setState(() {
+                          _avatarUrl = avatarUrl;
+                        });
+                      }
+                    },
+                    child: CircleAvatar(
+                      radius: 50,
+                      backgroundImage: _avatarUrl != null ? NetworkImage(_avatarUrl!) : null,
+                      child: _avatarUrl == null ? const Icon(Icons.person, size: 50) : null,
+                    ),
+                  ),
+                ),
+                const SizedBox(height: 16),
+                TextField(
+                  controller: _usernameController,
+                  decoration: const InputDecoration(labelText: 'Username'),
+                ),
+                const SizedBox(height: 16),
+                TextField(
+                  controller: _displayNameController,
+                  decoration: const InputDecoration(labelText: 'Display Name'),
+                ),
+                const SizedBox(height: 16),
+                TextField(
+                  controller: _bioController,
+                  decoration: const InputDecoration(labelText: 'Bio'),
+                ),
+                const SizedBox(height: 16),
+                ElevatedButton(
+                  onPressed: () async {
+                    final updatedProfile = UserProfile(
+                      id: userProfile.id,
+                      username: _usernameController.text,
+                      displayName: _displayNameController.text,
+                      bio: _bioController.text,
+                      avatarUrl: _avatarUrl,
+                      socialLinks: userProfile.socialLinks,
+                      isPublic: userProfile.isPublic,
+                      createdAt: userProfile.createdAt,
+                      updatedAt: DateTime.now(),
+                    );
+                    await _controller.upsertUserProfile(updatedProfile);
+                    ScaffoldMessenger.of(context).showSnackBar(
+                      const SnackBar(content: Text('Profile updated successfully')),
+                    );
+                  },
+                  child: const Text('Save'),
+                ),
+              ],
+            ),
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/ui/screens/wardrobe/settings/page.dart
+++ b/lib/ui/screens/wardrobe/settings/page.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-
+import 'package:go_router/go_router.dart';
 
 class SettingsPage extends StatelessWidget {
   const SettingsPage({Key? key}) : super(key: key);
@@ -16,31 +16,26 @@ class SettingsPage extends StatelessWidget {
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             ListTile(
-              
               title: const Text('Account'),
               onTap: () {
-                // Navigate to account settings
-                Navigator.pushNamed(context, '/settings/account');
+                context.push('/settings/account');
               },
             ),
             ListTile(
               title: const Text('Notifications'),
               onTap: () {
-                // Navigate to notification settings
                 Navigator.pushNamed(context, '/settings/notifications');
               },
             ),
             ListTile(
               title: const Text('Privacy'),
               onTap: () {
-                // Navigate to privacy settings
                 Navigator.pushNamed(context, '/settings/privacy');
               },
             ),
             ListTile(
               title: const Text('About'),
               onTap: () {
-                // Navigate to about page
                 Navigator.pushNamed(context, '/settings/about');
               },
             ),


### PR DESCRIPTION
Add settings account page view and controller to upsert user profile, load initial data, and include avatar uploader.

* **Controller**: Add `SettingsAccountController` in `lib/controllers/settings_account_controller.dart` to handle upserting user profile, loading initial data, and image uploading.
* **Dependency Injection**: Update `lib/di/service_locator.dart` to register `SettingsAccountController`.
* **Routing**: Update `lib/router/app_router.dart` to include a route for the settings account page.
* **View**: Add `lib/ui/screens/wardrobe/settings/account_page.dart` to create the settings account page view with avatar uploader and profile data.
* **Navigation**: Update `lib/ui/screens/wardrobe/settings/page.dart` to navigate to the new settings account page when "Account" option is selected.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/OpenWardrobe/app/pull/17?shareId=ec4f085e-28a2-4024-a383-8af11eb642ac).